### PR TITLE
Change Plurk base URL to HTTPS

### DIFF
--- a/plurk_oauth/oauth.py
+++ b/plurk_oauth/oauth.py
@@ -17,7 +17,7 @@ else:
 
 class PlurkOAuth:
     def __init__(self, customer_key=None, customer_secret=None):
-        self.base_url = 'http://www.plurk.com'
+        self.base_url = 'https://www.plurk.com'
         self.request_token_url = '/OAuth/request_token'
         self.authorization_url = '/OAuth/authorize'
         self.access_token_url = '/OAuth/access_token'


### PR DESCRIPTION
Due to recent change in Plurk, all non-secure requests got 301 redirected to HTTPS. Then a check in https://github.com/clsung/plurk-oauth/blob/master/plurk_oauth/api.py#L50 makes all non-200 requests to fails.

The simplest fix to this is by making all requests HTTPS by default.